### PR TITLE
Fix broken CE links in examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for (const auto& i : opt) {
 ```
 
 Full code can be found in [./examples/range_loop.cpp](./examples/range_loop.cpp). Build and run instructions in
-[./examples/README.md](./examples/README.md). Or [try it on Compiler Explorer](https://godbolt.org/z/b5ThEqqhf).
+[./examples/README.md](./examples/README.md). Or try it on Compiler Explorer: [range_loop.cpp@Compiler Explorer](https://godbolt.org/z/Gc6Y9j6zf).
 
 ### optional_ref
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,9 +10,9 @@ List of usage examples for `beman.optional`.
 
 Check basic `beman.optional` library usages:
 
-* local [./sample.cpp](./sample.cpp) or [sample.cpp@Compiler Explorer](https://godbolt.org/z/47vGje65x)
-* local [./std_vs_beman.cpp](./std_vs_beman.cpp) or [std_vs_beman.cpp@Compiler Explorer](https://godbolt.org/z/ds5MvfGe6)
-* local [./concept_checks.cpp](./concep_checks.cpp) or [concept_checks.cpp@Compiler Explorer](https://godbolt.org/z/7eYb4Wbjc)
+* local [./sample.cpp](./sample.cpp) or [sample.cpp@Compiler Explorer](https://godbolt.org/z/ebEzYc5fv)
+* local [./std_vs_beman.cpp](./std_vs_beman.cpp) or [std_vs_beman.cpp@Compiler Explorer](https://godbolt.org/z/P1c8x135M)
+* local [./concept_checks.cpp](./concep_checks.cpp) or [concept_checks.cpp@Compiler Explorer](https://godbolt.org/z/9893TMod4)
 
 ### Local Build and Run
 
@@ -38,8 +38,8 @@ $ .build/gcc-14/examples/RelWithDebInfo/concept_checks
 
 Range support added in [*Give std::optional Range Support* (P3168R2)](https://wg21.link/P3168R2) examples:
 
-* local [./range_loop.cpp](./range_loop.cpp) or [range_loop.cpp@Compiler Explorer](https://godbolt.org/z/f8dWaxsGo)
-* local [./pythagorean_triples.cpp](./pythagorean_triples.cpp) or [pythagorean_triples.cpp@Compiler Explorer](https://godbolt.org/z/fGr8jYM6P)
+* local [./range_loop.cpp](./range_loop.cpp) or [range_loop.cpp@Compiler Explorer](https://godbolt.org/z/Gc6Y9j6zf)
+* local [./pythagorean_triples.cpp](./pythagorean_triples.cpp) or [pythagorean_triples.cpp@Compiler Explorer](https://godbolt.org/z/hjvj4ez7W)
 
 ### Local Build and Run
 
@@ -72,7 +72,7 @@ First 10 Pythagorean triples:
 
 Reference support added in [*std::optional<T&>*(P2988R5)](https://wg21.link/P2988R5) examples:
 
-* local [./optional_ref.cpp](./optional_ref.cpp) or [optional_ref.cpp@Compiler Explorer](https://godbolt.org/z/nbfjsY9Gs)
+* local [./optional_ref.cpp](./optional_ref.cpp) or [optional_ref.cpp@Compiler Explorer](https://godbolt.org/z/MxjdvTTov)
 
 ### Local Build and Run
 


### PR DESCRIPTION
https://github.com/bemanproject/beman/issues/85

Run example:

![image](https://github.com/user-attachments/assets/2d1714c7-e7d0-4774-a21f-28286d0e7674)
