### PR TITLE
Format kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 # cmake-format: on
 
 INSTALL_PREFIX?=.install/
-PROJECT?=$(shell basename $(CURDIR))
 BUILD_DIR?=.build
 DEST?=$(INSTALL_PREFIX)
 CMAKE_FLAGS?=
@@ -62,8 +61,10 @@ $(_build_path)/CMakeCache.txt: | $(_build_path) .gitmodules
 
 TARGET:=all
 compile: $(_build_path)/CMakeCache.txt ## Compile the project
-	cmake --build $(_build_path)  --config $(CONFIG) --target all_verify_interface_header_sets -- -k 0
 	cmake --build $(_build_path)  --config $(CONFIG) --target all -- -k 0
+
+compile-headers: $(_build_path)/CMakeCache.txt ## Compile the headers
+	 cmake --build $(_build_path)  --config $(CONFIG) --target all_verify_interface_header_sets -- -k 0
 
 install: $(_build_path)/CMakeCache.txt compile ## Install the project
 	cmake --install $(_build_path) --config $(CONFIG) --component beman_optional_development --verbose
@@ -98,7 +99,7 @@ papers:
 	cmake --build $(_build_path)  --config $(CONFIG) --target $@ -- -k 0
 
 PYEXECPATH ?= $(shell which python3.12 || which python3.11 || which python3.10 || which python3.9 || which python3.8 || which python3.7 || which python3)
-PYTHON ?= $(shell basename $(PYEXECPATH))
+PYTHON ?= $(notdir $(PYEXECPATH))
 VENV := .venv
 ACTIVATE := . $(VENV)/bin/activate &&
 PYEXEC := $(ACTIVATE) $(PYTHON)

--- a/etc/gcc-15-toolchain.cmake
+++ b/etc/gcc-15-toolchain.cmake
@@ -4,6 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/gcc-flags.cmake")
 
 set(CMAKE_C_COMPILER gcc-15)
 set(CMAKE_CXX_COMPILER g++-15)
+set(GCOV_EXECUTABLE "gcov-15" CACHE STRING "GCOV executable" FORCE)
 
 set(CMAKE_CXX_FLAGS_ASAN
     "${CMAKE_CXX_FLAGS_ASAN} -Wno-maybe-uninitialized"

--- a/etc/gcc-16-toolchain.cmake
+++ b/etc/gcc-16-toolchain.cmake
@@ -1,0 +1,13 @@
+include_guard(GLOBAL)
+
+include("${CMAKE_CURRENT_LIST_DIR}/gcc-flags.cmake")
+
+set(CMAKE_C_COMPILER gcc-16)
+set(CMAKE_CXX_COMPILER g++-16)
+
+set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_ASAN} -Wno-maybe-uninitialized"
+    CACHE STRING
+    "C++ ASAN Flags"
+    FORCE
+)

--- a/etc/gcc-16-toolchain.cmake
+++ b/etc/gcc-16-toolchain.cmake
@@ -4,6 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/gcc-flags.cmake")
 
 set(CMAKE_C_COMPILER gcc-16)
 set(CMAKE_CXX_COMPILER g++-16)
+set(GCOV_EXECUTABLE "gcov-16" CACHE STRING "GCOV executable" FORCE)
 
 set(CMAKE_CXX_FLAGS_ASAN
     "${CMAKE_CXX_FLAGS_ASAN} -Wno-maybe-uninitialized"

--- a/etc/gcc-flags.cmake
+++ b/etc/gcc-flags.cmake
@@ -2,7 +2,7 @@ include_guard(GLOBAL)
 
 set(CMAKE_CXX_STANDARD 23)
 
-set(CMAKE_CXX_FLAGS "-std=c++23 -Wall -Wextra " CACHE STRING "CXX_FLAGS" FORCE)
+set(CMAKE_CXX_FLAGS "-Wall -Wextra " CACHE STRING "CXX_FLAGS" FORCE)
 
 set(CMAKE_CXX_FLAGS_DEBUG
     "-O0 -fno-inline -g3"

--- a/include/beman/optional/optional.hpp
+++ b/include/beman/optional/optional.hpp
@@ -4,6 +4,7 @@
 #ifndef BEMAN_OPTIONAL_OPTIONAL_HPP
 #define BEMAN_OPTIONAL_OPTIONAL_HPP
 
+#include <version>
 #include <compare>
 #include <concepts>
 #if defined(__cpp_lib_format_ranges)

--- a/tests/beman/optional/optional_range_support.t.cpp
+++ b/tests/beman/optional/optional_range_support.t.cpp
@@ -231,6 +231,23 @@ TEST(RangeSupportTest, EndOnNonEmptyOptional) {
     lambda();
 }
 
+#if ((__GNUC__ >= 15) && (__GNUC_MINOR__ >= 1) && (__GNUC_PATCHLEVEL__ >= 1)) || \
+  ((__GNUC__ >= 16))
+static_assert(std::format_kind<beman::optional::optional<int>> == std::range_format::disabled);
+#endif
+
+#if defined(__cpp_lib_format_ranges)
+static_assert(std::format_kind<beman::optional::optional<int>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<int&>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<int*>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<empty>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<empty&>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<base>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<base&>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<derived>> == std::range_format::disabled);
+static_assert(std::format_kind<beman::optional::optional<derived&>> == std::range_format::disabled);
+#endif
+
 TEST(RangeSupportTest, FormatOptionalIsStillDisabled) {
 // TODO: Always enable when all major compilers implement P2585R1: "Improve default container formatting".
 #if defined(__cpp_lib_format_ranges)

--- a/tests/beman/optional/optional_range_support.t.cpp
+++ b/tests/beman/optional/optional_range_support.t.cpp
@@ -231,8 +231,7 @@ TEST(RangeSupportTest, EndOnNonEmptyOptional) {
     lambda();
 }
 
-#if ((__GNUC__ >= 15) && (__GNUC_MINOR__ >= 1) && (__GNUC_PATCHLEVEL__ >= 1)) || \
-  ((__GNUC__ >= 16))
+#if ((__GNUC__ >= 15) && (__GNUC_MINOR__ >= 1) && (__GNUC_PATCHLEVEL__ >= 1)) || ((__GNUC__ >= 16))
 static_assert(std::format_kind<beman::optional::optional<int>> == std::range_format::disabled);
 #endif
 


### PR DESCRIPTION
GCC 15 release branch and GCC 16 have support for format_kind, revealing that the support in beman.optional has always been broken. 