### PR TITLE
Constexpr 20

### DIFF
--- a/etc/clang-flags.cmake
+++ b/etc/clang-flags.cmake
@@ -1,6 +1,6 @@
 include_guard(GLOBAL)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_CXX_FLAGS
     "-stdlib=libc++ -Wall -Wextra "
@@ -28,13 +28,13 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
     FORCE
 )
 set(CMAKE_CXX_FLAGS_TSAN
-    "-O3 -g -DNDEBUG -fsanitize=thread"
+    "-O3 -g -fsanitize=thread"
     CACHE STRING
     "C++ TSAN Flags"
     FORCE
 )
 set(CMAKE_CXX_FLAGS_ASAN
-    "-O3 -g -DNDEBUG -fsanitize=address,undefined,leak"
+    "-O3 -g -fsanitize=address,undefined,leak"
     CACHE STRING
     "C++ ASAN Flags"
     FORCE

--- a/etc/gcc-flags.cmake
+++ b/etc/gcc-flags.cmake
@@ -1,6 +1,6 @@
 include_guard(GLOBAL)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra " CACHE STRING "CXX_FLAGS" FORCE)
 
@@ -23,13 +23,13 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
     FORCE
 )
 set(CMAKE_CXX_FLAGS_TSAN
-    "-O3 -g -DNDEBUG -fsanitize=thread"
+    "-O3 -g -fsanitize=thread"
     CACHE STRING
     "C++ TSAN Flags"
     FORCE
 )
 set(CMAKE_CXX_FLAGS_ASAN
-    "-O3 -g -DNDEBUG -fsanitize=address,undefined,leak"
+    "-O3 -g -fsanitize=address,undefined,leak"
     CACHE STRING
     "C++ ASAN Flags"
     FORCE

--- a/etc/gcc-toolchain.cmake
+++ b/etc/gcc-toolchain.cmake
@@ -3,12 +3,7 @@ include_guard(GLOBAL)
 set(CMAKE_C_COMPILER gcc)
 set(CMAKE_CXX_COMPILER g++)
 
-set(CMAKE_CXX_FLAGS
-    "-Wall -Wextra "
-    CACHE STRING
-    "CXX_FLAGS"
-    FORCE
-)
+set(CMAKE_CXX_FLAGS "-Wall -Wextra " CACHE STRING "CXX_FLAGS" FORCE)
 
 set(CMAKE_CXX_FLAGS_DEBUG
     "-O0 -fno-inline -g3"

--- a/etc/gcc-toolchain.cmake
+++ b/etc/gcc-toolchain.cmake
@@ -4,8 +4,7 @@ set(CMAKE_C_COMPILER gcc)
 set(CMAKE_CXX_COMPILER g++)
 
 set(CMAKE_CXX_FLAGS
-    "-std=c++20 \
-   -Wall -Wextra "
+    "-Wall -Wextra "
     CACHE STRING
     "CXX_FLAGS"
     FORCE

--- a/tests/beman/optional/optional_range_support.t.cpp
+++ b/tests/beman/optional/optional_range_support.t.cpp
@@ -27,7 +27,6 @@
 #include <unordered_set>
 #include <vector>
 
-
 #define CONSTEXPR_EXPECT_TRUE(val)        \
     if (::std::is_constant_evaluated()) { \
         if (!(val)) {                     \
@@ -112,7 +111,6 @@ TEST(RangeSupportTest, IteratorConcepts) {
     test(beman::optional::optional<base>{});
     test(beman::optional::optional<derived>{});
 }
-
 
 TEST(RangeSupportTest, BeginOnEmptyOptional) {
     auto lambda = [&] {
@@ -227,7 +225,7 @@ TEST(RangeSupportTest, EndOnNonEmptyOptional) {
     EXPECT_TRUE(lambda());
 }
 
-#if (__cplusplus >=  202302L) && \
+#if (__cplusplus >= 202302L) && \
     (((__GNUC__ >= 15) && (__GNUC_MINOR__ >= 1) && (__GNUC_PATCHLEVEL__ >= 1)) || ((__GNUC__ >= 16)))
 static_assert(std::format_kind<beman::optional::optional<int>> == std::range_format::disabled);
 #endif
@@ -323,7 +321,7 @@ TEST(RangeSupportTest, LoopOptionalAssignment) {
         // Example from P3168R2: should mutate the value from an optional object.
         constexpr int  initial_expected_value = 0xCAFEBABE;
         constexpr int  expected_value         = 0xDEADBEEF;
-        constexpr auto get_optional           = [=]() -> beman::optional::optional<int> { return initial_expected_value; };
+        constexpr auto get_optional = [=]() -> beman::optional::optional<int> { return initial_expected_value; };
         constexpr_assert(get_optional().has_value());
         constexpr_assert(get_optional().value() == initial_expected_value);
 


### PR DESCRIPTION
Make unit testing constexpr compatible in C++20. 

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120868 was in the way, at least partially. 

Fixes #123 