### PR TITLE
Update CODEOWNERS: remove deprecated group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Codeowners for reviews on PRs
 
-*       @camio @neatudarius @steve-downey @bemanproject/core-reviewers
+* @steve-downey @neatudarius @camio 


### PR DESCRIPTION
Update CODEOWNERS: remove deprecated group https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners

(tweak the order)