### PR TITLE
Remove meaningless lint comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 #! /usr/bin/make -f
-# cmake-format: off
 # /Makefile -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# cmake-format: on
 
 INSTALL_PREFIX?=.install/
 BUILD_DIR?=.build


### PR DESCRIPTION
Makefile is not a cmake file, so cmake-format is irrelevant.