### PR TITLE
Disable Clang 18 C++26 libstdc++ unit tests due to incompatibility with version 15

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -93,11 +93,25 @@ jobs:
                 }
               ]
             },
-            { "versions": ["20", "19", "18"],
+            { "versions": ["20", "19"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
+                  ]
+                }
+              ]
+            },
+            { "versions": ["18"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [
+                    {"stdlibs": ["libc++"], "tests": ["Release.Default"]}
+                  ]
+                },
+                { "cxxversions": ["c++23", "c++20"],
+                  "tests": [
+                    {"stdlibs": ["libc++"], "tests": ["Release.Default"]}
                   ]
                 }
               ]


### PR DESCRIPTION
See https://github.com/bemanproject/exemplar/commit/48638eeb25ccfe125b3db13deb1001326e012317