### PR TITLE
Revert "Comment out submodule check"

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -15,10 +15,8 @@ on:
     - cron: '30 15 * * *'
 
 jobs:
-  # Optional is out of sync with upstream submodule while telemetry is under review
-  # https://github.com/bemanproject/infra/pull/23
-  # beman-submodule-check:
-  #   uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@82c1c6c07039084f047e56ef806612b9e2fa45cf # 1.5.0
+  beman-submodule-check:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@82c1c6c07039084f047e56ef806612b9e2fa45cf # 1.5.0
 
   preset-test:
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@82c1c6c07039084f047e56ef806612b9e2fa45cf # 1.5.0


### PR DESCRIPTION
This reverts commit ed4cd79fc147f5783bd6cc5738479f32c28ab154, since optional is now back in sync with the upstream copy of infra.