### PR TITLE
Update gersemi pre-commit hook to new repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
       types_or: [c++, c]
 
     # CMake linting and formatting
-  - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.26.1
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.2
     hooks:
     - id: gersemi
       name: CMake linting


### PR DESCRIPTION
The gersemi project moved its pre-commit hook definition to a
separate repository (BlankSpruce/gersemi-pre-commit) starting
with v0.27.1, removing .pre-commit-hooks.yaml from the main repo.
This broke the weekly pre-commit autoupdate CI workflow.

See: https://github.com/BlankSpruce/gersemi/commit/e647b52384c05ddfc397664e73c822dacd5b0b75

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>