### PR TITLE
Enable beman-tidy (--require-all mode) into beman.optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,11 @@ repos:
             papers/.*
           )$
 
+    # Beman Standard checking via beman-tidy
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.3.1
+    hooks:
+    - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
+
 exclude: 'infra/'


### PR DESCRIPTION
Issue - https://github.com/bemanproject/beman-tidy/issues/247

Updates: Enable beman-tidy (--require-all mode) into beman.optional. All checks already pass before this PR.