### PR TITLE
Align BEMAN_OPTIONAL_BUILD_TESTS with Beman Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ include(FetchContent)
 set(TARGETS_EXPORT_NAME ${PROJECT_NAME}Targets)
 
 option(
-    OPTIONAL_ENABLE_TESTING
-    "Enable building tests and test infrastructure"
+    BEMAN_OPTIONAL_BUILD_TESTS
+    "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
 
@@ -27,7 +27,7 @@ target_sources(
     PUBLIC FILE_SET beman_optional_headers TYPE HEADERS BASE_DIRS include
 )
 
-if(OPTIONAL_ENABLE_TESTING)
+if(BEMAN_OPTIONAL_BUILD_TESTS)
     find_package(GTest QUIET)
     if(GTest_FOUND)
         # Create the library target and named header set for testing beman.optional

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Build-time dependencies:
 * `cmake`
 * `ninja`, `make`, or another CMake-supported build system
   * CMake defaults to "Unix Makefiles" on POSIX systems
+* (Test Only) GoogleTest
+
+You can disable building tests by setting CMake option `BEMAN_OPTIONAL_BUILD_TESTS` to
+`OFF` when configuring the project.
 
 Example of installation on `Ubuntu 24.04`:
 
@@ -192,7 +196,7 @@ consequently have the highest optimization turned on (e.g. `O3`).
 CI current build and test flows:
 
 ```shell
-# Configure build: default build production code + tests (OPTIONAL_ENABLE_TESTING=ON by default).
+# Configure build: default build production code + tests (BEMAN_OPTIONAL_BUILD_TESTS=ON by default).
 $ cmake -G "Ninja Multi-Config" \
       -DCMAKE_CONFIGURATION_TYPES="RelWithDebInfo;Asan" \
       -DCMAKE_TOOLCHAIN_FILE=etc/clang-19-toolchain.cmake \
@@ -218,14 +222,15 @@ Total Test time (real) =   0.67 sec
 
 ##### Build Production, but Skip Tests
 
-By default, we build and run tests. You can provide `-DOPTIONAL_ENABLE_TESTING=OFF` and completely disable building tests:
+By default, we build and run tests. You can disable building tests by setting CMake
+option `BEMAN_OPTIONAL_BUILD_TESTS` to `OFF` when configuring the project:
 
 ```shell
-# Configure build: build production code, skip tests (OPTIONAL_ENABLE_TESTING=OFF).
+# Configure build: build production code, skip tests (BEMAN_OPTIONAL_BUILD_TESTS=OFF).
 $ cmake -G "Ninja Multi-Config" \
       -DCMAKE_CONFIGURATION_TYPES="RelWithDebInfo;Asan" \
       -DCMAKE_TOOLCHAIN_FILE=etc/clang-19-toolchain.cmake \
-      -DOPTIONAL_ENABLE_TESTING=OFF \
+      -DBEMAN_OPTIONAL_BUILD_TESTS=OFF \
       -B .build -S .
 -- The CXX compiler identification is Clang 19.0.0
 ...


### PR DESCRIPTION
Related to upcoming new beman-tidy new feature: https://github.com/bemanproject/beman-tidy/pull/346. Changes in this library needs to be fixed before releasing new beman-tidy including this feature.

## Summary
- Rename `OPTIONAL_ENABLE_TESTING` to `BEMAN_OPTIONAL_BUILD_TESTS`
- Use standard option description with `${PROJECT_IS_TOP_LEVEL}` default
- Update README references

Satisfies `cmake.skip_tests` from beman-tidy.

## Test plan
- [x] `beman-tidy` — `cmake.skip_tests` passes locally
- [ ] CI green
